### PR TITLE
Fixed off-by-one error in counter wraparound.

### DIFF
--- a/metrics/counter.js
+++ b/metrics/counter.js
@@ -17,7 +17,7 @@ Counter.prototype.inc = function(val) {
   this.count += val;
   // Wrap counter if necessary.
   if (this.count > MAX_COUNTER_VALUE) {
-    this.count -= MAX_COUNTER_VALUE;
+    this.count -= (MAX_COUNTER_VALUE + 1);
   }
 }
 


### PR DESCRIPTION
Correct test case:

``` javascript
> var Counter = require('metrics').Counter;
> x = new Counter();
{ count: 0, type: 'counter' }
> x.inc(Math.pow(2,32))
> x
{ count: 4294967296, type: 'counter' }
> x.inc(2)
> x
{ count: 1, type: 'counter' }
```
