### PR TITLE
decouple-reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-
-
-
 var Metrics = require('./metrics')
   , Reporting = require('./reporting');
 
@@ -10,6 +7,7 @@ exports.Counter = Metrics.Counter;
 exports.Timer = Metrics.Timer;
 
 exports.Server = Reporting.Server;
+exports.Report = Reporting.Report;
 
 exports.version = '0.0.1';
 

--- a/reporting/index.js
+++ b/reporting/index.js
@@ -1,3 +1,2 @@
-
+exports.Report = require('./report');
 exports.Server = require('./server');
-

--- a/reporting/report.js
+++ b/reporting/report.js
@@ -1,0 +1,29 @@
+/**
+* trackedMetrics is an object with eventTypes as keys and metrics object as values.
+*/
+var Report = module.exports = function (trackedMetrics){
+  this.trackedMetrics = trackedMetrics || {};
+}
+
+Report.prototype.addMetric = function(eventName, metric) {
+  var namespaces = eventName.split('.')
+    , event = namespaces.pop()
+    , namespace = namespaces.join('.');
+  if (!this.trackedMetrics[namespace]) {
+    this.trackedMetrics[namespace] = {};
+  }
+  if(!this.trackedMetrics[namespace][event]) {
+    this.trackedMetrics[namespace][event] = metric;
+  }
+}
+
+Report.prototype.summary = function (){
+  var metricsObj = {};
+  for (namespace in this.trackedMetrics) {
+    metricsObj[namespace] = {};
+    for (event in this.trackedMetrics[namespace]) {
+      metricsObj[namespace][event] = this.trackedMetrics[namespace][event].printObj();
+    }
+  }
+  return metricsObj;
+}

--- a/reporting/server.js
+++ b/reporting/server.js
@@ -1,23 +1,19 @@
-var http = require('http');
+var http = require('http')
+  , Report = require('./report');
+
+
 /**
-* trackedMetrics is an object with eventTypes as keys and metrics object as values.
-* This server will print the object upon request.  The user should update the metrics
-* as normal within their application.
-*/
+ * This server will print the object upon request.  The user should update the metrics
+ * as normal within their application.
+ */
 var Server = module.exports = function Server(port, trackedMetrics) {
   var self = this;
-  this.trackedMetrics = trackedMetrics || {};
+  this.report = new Report(trackedMetrics);
+
   this.server = http.createServer(function (req, res) {
     if (req.url.match(/^\/metrics/)) {
       res.writeHead(200, {'Content-Type': 'application/json'});
-      var metricsObj = {};
-      for (namespace in self.trackedMetrics) {
-        metricsObj[namespace] = {};
-        for (event in self.trackedMetrics[namespace]) {
-          metricsObj[namespace][event] = self.trackedMetrics[namespace][event].printObj();
-        }
-      }
-      res.end(JSON.stringify(metricsObj));
+      res.end(JSON.stringify(self.report.summary()));
     } else {
       res.writeHead(404, {'Content-Type': 'text/plain'});
       res.end('Try hitting /metrics instead');
@@ -25,15 +21,9 @@ var Server = module.exports = function Server(port, trackedMetrics) {
   }).listen(port, "127.0.0.1");
 }
 
-Server.prototype.addMetric = function(eventName, metric) {
-  var namespaces = eventName.split('.')
-    , event = namespaces.pop()
-    , namespace = namespaces.join('.');
-  if (!this.trackedMetrics[namespace]) {
-    this.trackedMetrics[namespace] = {};
-  }
-  if(!this.trackedMetrics[namespace][event]) {
-    this.trackedMetrics[namespace][event] = metric;
-  }
+/**
+ * Adds a metric to be tracked by this server
+ */
+Server.prototype.addMetric = function (){
+  this.report.addMetric.apply(this.report, arguments);
 }
-


### PR DESCRIPTION
Decouple reporting from server so reporting can be used without running a server on a separate port
