### PR TITLE
Require node 0.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib": "."
   },
   "engines": {
-    "node": ">=0.4.x"
+    "node": ">=0.10.x"
   },
   "dependencies": {},
   "devDependencies": {}


### PR DESCRIPTION
dbd18d0e12a1c8bb477100c2f834a37a07b342db introduced the use of Timer.unref(), which is not supported on node 0.8.x or earlier.