### PR TITLE
Stop leaking globals into other projects.

### DIFF
--- a/metrics/timer.js
+++ b/metrics/timer.js
@@ -1,6 +1,7 @@
-var Meter = require('./meter');
-Histogram = require('./histogram')
-ExponentiallyDecayingSample = require('../stats/exponentially_decaying_sample');
+var Meter = require('./meter'),
+    Histogram = require('./histogram'),
+    ExponentiallyDecayingSample = require('../stats/exponentially_decaying_sample');
+
 /*
 *  Basically a timer tracks the rate of events and histograms the durations
 */


### PR DESCRIPTION
We had some unrelated issues with interacting tests which got me digging into values being added to the global object.

Found these and here's the fix.