### PR TITLE
Fixed EWMA global leak.

### DIFF
--- a/stats/exponentially_weighted_moving_average.js
+++ b/stats/exponentially_weighted_moving_average.js
@@ -9,7 +9,7 @@ var M1_ALPHA = 1 - Math.exp(-5/60);
 var M5_ALPHA = 1 - Math.exp(-5/60/5);
 var M15_ALPHA = 1 - Math.exp(-5/60/15);
 
-var ExponentiallyWeightedMovingAverage = EWMA = module.exports = function ExponentiallyWeightedMovingAverage(alpha, interval) {
+var EWMA = module.exports = function(alpha, interval) {
   var self = this;
   this.alpha = alpha;
   this.interval = interval || 5000;
@@ -24,14 +24,14 @@ var ExponentiallyWeightedMovingAverage = EWMA = module.exports = function Expone
   }
 }
 
-ExponentiallyWeightedMovingAverage.prototype.update = function(n) {
+EWMA.prototype.update = function(n) {
   this.uncounted += (n || 1);
 }
 
 /*
  * Update our rate measurements every interval
  */
-ExponentiallyWeightedMovingAverage.prototype.tick = function() {
+EWMA.prototype.tick = function() {
   var  instantRate = this.uncounted / this.interval;
   this.uncounted = 0;
   
@@ -46,11 +46,11 @@ ExponentiallyWeightedMovingAverage.prototype.tick = function() {
 /*
  * Return the rate per second
  */
-ExponentiallyWeightedMovingAverage.prototype.rate = function() {
+EWMA.prototype.rate = function() {
   return this.currentRate * 1000;
 }
 
-ExponentiallyWeightedMovingAverage.prototype.stop = function() {
+EWMA.prototype.stop = function() {
   clearInterval(this.tickInterval);
 }
 


### PR DESCRIPTION
The longer variable name wasn't available outside of this file and the double assignment wasn't working as intended, it was instead leaking the EWMA variable into the global scope.