### PR TITLE
ScheduledReporter with console, csv and graphite implementations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ metricsServer.addMetric('com.co.thingD', meter);
 metricsServer.addMetric('com.co.thingE', timer);
 ```
 
+**Setting up a Reporter**
+
+A reporting interface exists for reporting metrics on a recurring interval.  Reporters can be found in [reporting/](reporting).
+
+```javascript
+// Report to console every 1000ms.
+var report = new metrics.Report();
+report.addMetric('com.co.thingA', counter);
+var reporter = new metrics.ConsoleReporter(report);
+
+reporter.start(1000);
+```
 
 Advanced Usage
 --------------

--- a/index.js
+++ b/index.js
@@ -9,5 +9,10 @@ exports.Timer = Metrics.Timer;
 exports.Server = Reporting.Server;
 exports.Report = Reporting.Report;
 
-exports.version = '0.1.5';
+exports.ScheduledReporter = Reporting.ScheduledReporter;
+exports.ConsoleReporter = Reporting.ConsoleReporter;
+exports.CsvReporter = Reporting.CsvReporter;
+exports.GraphiteReporter = Reporting.GraphiteReporter;
+
+exports.version = '0.1.10';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrics",
   "description": "A node.js port of Coda Hale's metrics library.  In use at Yammer.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "repository": {
     "type": "git",
     "url": "git://github.com/mikejihbe/metrics.git"

--- a/reporting/console-reporter.js
+++ b/reporting/console-reporter.js
@@ -68,7 +68,7 @@ function printMeter(meter) {
   console.log('             count = %d', meter.count);
   console.log('         mean rate = %s events/%s', ff(meter.meanRate()), 'second');
   console.log('     1-minute rate = %s events/%s', ff(meter.oneMinuteRate()), 'second');
-  console.log('     1-minute rate = %s events/%s', ff(meter.fiveMinuteRate()), 'second');
+  console.log('     5-minute rate = %s events/%s', ff(meter.fiveMinuteRate()), 'second');
   console.log('    15-minute rate = %s events/%s', ff(meter.fifteenMinuteRate()), 'second');
 }
 
@@ -77,7 +77,7 @@ function printTimer(timer) {
   console.log('             count = %d', timer.count());
   console.log('         mean rate = %s events/%s', ff(timer.meanRate()), 'second');
   console.log('     1-minute rate = %s events/%s', ff(timer.oneMinuteRate()), 'second');
-  console.log('     1-minute rate = %s events/%s', ff(timer.fiveMinuteRate()), 'second');
+  console.log('     5-minute rate = %s events/%s', ff(timer.fiveMinuteRate()), 'second');
   console.log('    15-minute rate = %s events/%s', ff(timer.fifteenMinuteRate()), 'second');
 
   var percentiles = timer.percentiles([.50,.75,.95,.98,.99,.999]);

--- a/reporting/console-reporter.js
+++ b/reporting/console-reporter.js
@@ -1,0 +1,98 @@
+'use strict';
+var ScheduledReporter = require('./scheduled-reporter.js'),
+  util = require('util');
+
+/**
+ * A custom reporter that prints all metrics on console.log at a defined interval.
+ * @param {Report} registry report instance whose metrics to report on.
+ * @constructor
+ */
+function ConsoleReporter(registry) {
+  ConsoleReporter.super_.call(this, registry);
+}
+
+util.inherits(ConsoleReporter, ScheduledReporter);
+
+ConsoleReporter.prototype.report = function() {
+  var metrics = this.getMetrics();
+
+  if(metrics.counters.length != 0) {
+    printWithBanner('Counters');
+    metrics.counters.forEach(function (counter) {
+      printCounter(counter);
+    });
+    console.log();
+  }
+
+  if(metrics.meters.length != 0) {
+    printWithBanner('Meters');
+    metrics.meters.forEach(function (meter) {
+      printMeter(meter);
+    });
+    console.log();
+  }
+
+  if(metrics.timers.length != 0) {
+    printWithBanner('Timers');
+    metrics.timers.forEach(function (timer) {
+      // Don't log timer if its recorded no metrics.
+      if(timer.min() != null) {
+        printTimer(timer);
+      }
+    });
+    console.log();
+  }
+};
+
+function printWithBanner(name) {
+  var dashLength = 80 - name.length - 1;
+  var dashes = "";
+  for(var i = 0; i < dashLength; i++) {
+    dashes += '-';
+  }
+  console.log('%s %s', name, dashes);
+}
+
+function ff(value) {
+  var fixed = value.toFixed(2);
+  return fixed >= 10 || fixed < 0 ? fixed : " " + fixed;
+}
+
+function printCounter(counter) {
+  console.log(counter.name);
+  console.log('             count = %d', counter.count);
+}
+
+function printMeter(meter) {
+  console.log(meter.name);
+  console.log('             count = %d', meter.count);
+  console.log('         mean rate = %s events/%s', ff(meter.meanRate()), 'second');
+  console.log('     1-minute rate = %s events/%s', ff(meter.oneMinuteRate()), 'second');
+  console.log('     1-minute rate = %s events/%s', ff(meter.fiveMinuteRate()), 'second');
+  console.log('    15-minute rate = %s events/%s', ff(meter.fifteenMinuteRate()), 'second');
+}
+
+function printTimer(timer) {
+  console.log(timer.name);
+  console.log('             count = %d', timer.count());
+  console.log('         mean rate = %s events/%s', ff(timer.meanRate()), 'second');
+  console.log('     1-minute rate = %s events/%s', ff(timer.oneMinuteRate()), 'second');
+  console.log('     1-minute rate = %s events/%s', ff(timer.fiveMinuteRate()), 'second');
+  console.log('    15-minute rate = %s events/%s', ff(timer.fifteenMinuteRate()), 'second');
+
+  var percentiles = timer.percentiles([.50,.75,.95,.98,.99,.999]);
+
+  console.log('               min = %s %s', ff(timer.min()), 'milliseconds');
+  console.log('               max = %s %s', ff(timer.max()), 'milliseconds');
+  console.log('              mean = %s %s', ff(timer.mean()), 'milliseconds');
+  console.log('            stddev = %s %s', ff(timer.stdDev()), 'milliseconds');
+  console.log('              50%% <= %s %s', ff(percentiles[.50]), 'milliseconds');
+  console.log('              75%% <= %s %s', ff(percentiles[.75]), 'milliseconds');
+  console.log('              95%% <= %s %s', ff(percentiles[.95]), 'milliseconds');
+  console.log('              98%% <= %s %s', ff(percentiles[.98]), 'milliseconds');
+  console.log('              99%% <= %s %s', ff(percentiles[.99]), 'milliseconds');
+  console.log('            99.9%% <= %s %s', ff(percentiles[.999]), 'milliseconds');
+}
+
+module.exports = ConsoleReporter;
+

--- a/reporting/csv-reporter.js
+++ b/reporting/csv-reporter.js
@@ -1,0 +1,108 @@
+'use strict';
+var ScheduledReporter = require('./scheduled-reporter.js'),
+  util = require('util'),
+  fs = require('fs');
+
+/**
+ * A custom reporter that will create a csv file for each metric that is appended to on the defined reporting interval.
+ * @param {Report} registry report instance whose metrics to report on.
+ * @param {String} directory Directory to put csv files in.
+ * @constructor
+ */
+function CsvReporter(registry, directory) {
+  CsvReporter.super_.call(this, registry);
+  this.directory = directory;
+}
+
+util.inherits(CsvReporter, ScheduledReporter);
+
+CsvReporter.prototype.report = function() {
+  var metrics = this.getMetrics();
+  var self = this;
+
+  var timestamp = (new Date).getTime() / 1000;
+
+  metrics.counters.forEach(function(counter) {
+    self.reportCounter.bind(self)(counter, timestamp);
+  });
+
+  metrics.meters.forEach(function(meter) {
+    self.reportMeter.bind(self)(meter, timestamp);
+  });
+
+  metrics.timers.forEach(function(timer) {
+    // Don't log timer if its recorded no metrics.
+    if(timer.min() != null) {
+      self.reportTimer.bind(self)(timer, timestamp);
+    }
+  })
+};
+
+CsvReporter.prototype.write = function(timestamp, name, header, line, values) {
+  var file = util.format('%s/%s.csv', this.directory, name);
+  // copy params and add line to the beginning and pass as arguments to util.format
+  // this operates like a quasi 'vsprintf'.
+  var params = values.slice();
+  params.unshift(line + "\n");
+  var data = util.format.apply(util, params);
+  data = util.format('%d,%s', timestamp, data);
+  fs.exists(file, function(exists) {
+    if(!exists) {
+      // include header if file didn't previously exist
+      data = util.format("t,%s\n%s", header, data);
+    }
+    fs.appendFile(file, data);
+  });
+};
+
+CsvReporter.prototype.reportCounter = function(counter, timestamp) {
+  var write = this.write.bind(this);
+
+  write(timestamp, counter.name, 'count', '%d', [counter.count]);
+};
+
+CsvReporter.prototype.reportMeter = function(meter, timestamp) {
+  var write = this.write.bind(this);
+
+  write(timestamp, meter.name,
+    'count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit',
+    '%d,%d,%d,%d,%d,events/%s', [
+      meter.count,
+      meter.meanRate(),
+      meter.oneMinuteRate(),
+      meter.fiveMinuteRate(),
+      meter.fifteenMinuteRate(),
+      'second'
+    ]
+  );
+};
+
+CsvReporter.prototype.reportTimer = function(timer, timestamp) {
+  var write = this.write.bind(this);
+  var percentiles = timer.percentiles([.50,.75,.95,.98,.99,.999]);
+
+  write(timestamp, timer.name,
+    'count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,' +
+    'm5_rate,m15_rate,rate_unit,duration_unit',
+    '%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,calls/%s,%s', [
+      timer.count(),
+      timer.max(),
+      timer.mean(),
+      timer.min(),
+      timer.stdDev(),
+      percentiles[.50],
+      percentiles[.75],
+      percentiles[.95],
+      percentiles[.98],
+      percentiles[.99],
+      percentiles[.999],
+      timer.meanRate(),
+      timer.oneMinuteRate(),
+      timer.fiveMinuteRate(),
+      timer.fifteenMinuteRate(),
+      'second',
+      'millisecond'
+    ]);
+};
+
+module.exports = CsvReporter;

--- a/reporting/graphite-reporter.js
+++ b/reporting/graphite-reporter.js
@@ -1,0 +1,122 @@
+'use strict';
+var ScheduledReporter = require('./scheduled-reporter.js'),
+  util = require('util'),
+  Socket = require('net').Socket;
+
+/**
+ * A custom reporter that sends metrics to a graphite server on the carbon tcp interface.
+ * @param {Report} registry report instance whose metrics to report on.
+ * @param {String} prefix A string to prefix on each metric (i.e. app.hostserver)
+ * @param {String} host The ip or hostname of the target graphite server.
+ * @param {String} port The port graphite is running on, defaults to 2003 if not specified.
+ * @constructor
+ */
+function GraphiteReporter(registry, prefix, host, port) {
+  GraphiteReporter.super_.call(this, registry);
+  this.prefix = prefix;
+  this.host = host;
+  this.port = port || 2003;
+}
+
+util.inherits(GraphiteReporter, ScheduledReporter);
+
+GraphiteReporter.prototype.start = function(intervalInMs) {
+  var self = this;
+  this.socket = new Socket();
+  this.socket.on('error', function(exc) {
+    self.emit('log', 'warn', util.format('Lost connection to %s. Will reconnect in 10 seconds.', self.host), exc);
+    // Stop the reporter and try again in 1 second.
+    self.stop();
+    setTimeout(function() {
+      self.start(intervalInMs);
+    }, 10000);
+  });
+
+  self.emit('log', 'verbose', util.format("Connecting to graphite @ %s:%d", this.host, this.port));
+  this.socket.connect(this.port, this.host, function() {
+    self.emit('log', 'verbose', util.format('Successfully connected to graphite @ %s:%d.', self.host, self.port));
+    GraphiteReporter.super_.prototype.start.call(self, intervalInMs);
+  });
+};
+
+GraphiteReporter.prototype.stop = function() {
+  GraphiteReporter.super_.prototype.stop.call(this);
+  this.socket.end();
+};
+
+GraphiteReporter.prototype.report = function() {
+  var metrics = this.getMetrics();
+  var self = this;
+  var timestamp = (new Date).getTime() / 1000;
+
+  if(metrics.counters.length != 0) {
+    metrics.counters.forEach(function (count) {
+      self.reportCounter.bind(self)(count, timestamp);
+    })
+  }
+
+  if(metrics.meters.length != 0) {
+    metrics.meters.forEach(function (meter) {
+      self.reportMeter.bind(self)(meter, timestamp);
+    })
+  }
+
+  if(metrics.timers.length != 0) {
+    metrics.timers.forEach(function (timer) {
+      // Don't log timer if its recorded no metrics.
+      if(timer.min() != null) {
+        self.reportTimer.bind(self)(timer, timestamp);
+      }
+    })
+  }
+};
+
+GraphiteReporter.prototype.send = function(name, value, timestamp) {
+  this.socket.write(util.format('%s.%s %s %s\n', this.prefix, name, value,
+    timestamp));
+};
+
+GraphiteReporter.prototype.reportCounter = function(counter, timestamp) {
+  var send = this.send.bind(this);
+
+  send(counter.name, counter.count, timestamp);
+};
+
+GraphiteReporter.prototype.reportMeter = function(meter, timestamp) {
+  var send = this.send.bind(this);
+
+  send(util.format('%s.%s', meter.name, 'count'), meter.count, timestamp);
+  send(util.format('%s.%s', meter.name, 'mean_rate'), meter.meanRate(), timestamp);
+  send(util.format('%s.%s', meter.name, 'm1_rate'), meter.oneMinuteRate(),
+    timestamp);
+  send(util.format('%s.%s', meter.name, 'm5_rate'), meter.fiveMinuteRate(),
+    timestamp);
+  send(util.format('%s.%s', meter.name, 'm15_rate'), meter.fifteenMinuteRate(),
+    timestamp);
+};
+
+GraphiteReporter.prototype.reportTimer = function(timer, timestamp) {
+  var send = this.send.bind(this);
+  send(util.format('%s.%s', timer.name, 'count'), timer.count(), timestamp);
+  send(util.format('%s.%s', timer.name, 'mean_rate'), timer.meanRate(), timestamp);
+  send(util.format('%s.%s', timer.name, 'm1_rate'), timer.oneMinuteRate(),
+    timestamp);
+  send(util.format('%s.%s', timer.name, 'm5_rate'), timer.fiveMinuteRate(),
+    timestamp);
+  send(util.format('%s.%s', timer.name, 'm15_rate'), timer.fifteenMinuteRate(),
+    timestamp);
+
+  var percentiles = timer.percentiles([.50,.75,.95,.98,.99,.999]);
+  send(util.format('%s.%s', timer.name, 'min'), timer.min(), timestamp);
+  send(util.format('%s.%s', timer.name, 'mean'), timer.mean(), timestamp);
+  send(util.format('%s.%s', timer.name, 'max'), timer.max(), timestamp);
+  send(util.format('%s.%s', timer.name, 'stddev'), timer.stdDev(), timestamp);
+  send(util.format('%s.%s', timer.name, 'p50'), percentiles[.50], timestamp);
+  send(util.format('%s.%s', timer.name, 'p75'), percentiles[.75], timestamp);
+  send(util.format('%s.%s', timer.name, 'p95'), percentiles[.95], timestamp);
+  send(util.format('%s.%s', timer.name, 'p98'), percentiles[.98], timestamp);
+  send(util.format('%s.%s', timer.name, 'p99'), percentiles[.99], timestamp);
+  send(util.format('%s.%s', timer.name, 'p999'), percentiles[.999], timestamp);
+};
+
+module.exports = GraphiteReporter;

--- a/reporting/index.js
+++ b/reporting/index.js
@@ -1,2 +1,6 @@
 exports.Report = require('./report');
 exports.Server = require('./server');
+exports.ScheduledReporter = require('./scheduled-reporter');
+exports.ConsoleReporter = require('./console-reporter');
+exports.CsvReporter = require('./csv-reporter');
+exports.GraphiteReporter = require('./graphite-reporter');

--- a/reporting/scheduled-reporter.js
+++ b/reporting/scheduled-reporter.js
@@ -1,0 +1,81 @@
+'use strict';
+var Counter = require('../metrics').Counter,
+  Meter = require('../metrics').Meter,
+  Timer = require('../metrics').Timer,
+  util = require('util'),
+  EventEmitter = require('events').EventEmitter;
+
+/**
+ * Creates a scheduled reporter instance with a given report instance.  This is meant to be extended and not used on
+ * its own, see {@link GraphiteReporter} for an example implementation.
+ * @param {Report} registry report instance whose metrics to report on.
+ * @constructor
+ */
+function ScheduledReporter(registry) {
+  ScheduledReporter.super_.call(this);
+  this.registry = registry;
+}
+
+util.inherits(ScheduledReporter, EventEmitter);
+
+/**
+ * Starts the calling {@link ScheduledReporter.report} on a scheduled interval.
+ * @param {Number} intervalInMs Number How often to report in milliseconds.
+ */
+ScheduledReporter.prototype.start = function(intervalInMs) {
+  this.interval = setInterval(this.report.bind(this), intervalInMs);
+};
+
+/**
+ * Stops the reporter if it was previously started.
+ */
+ScheduledReporter.prototype.stop = function() {
+  if('interval' in this) {
+    clearInterval(this.interval);
+  }
+};
+
+/**
+ * Method that is called on every intervalInMs that was passed into {@link ScheduledReporter.start}.  This method
+ * does nothing and should be overridden by implementers.
+ */
+ScheduledReporter.prototype.report = function() {
+  // implemented by children.
+};
+
+/**
+ * Retrieve the metrics associated with the report given to this reporter in a format that's easy to consume
+ * by reporters.  That is an object with separate references for meters, timers and counters.
+ * @returns {{meters: Array, timers: Array, counters: Array}}
+ */
+ScheduledReporter.prototype.getMetrics = function() {
+  var meters = [];
+  var timers = [];
+  var counters = [];
+
+  var trackedMetrics = this.registry.trackedMetrics;
+  // Flatten metric name to be namespace.name is has a namespace and separate out metrics
+  // by type.
+  for(var namespace in trackedMetrics) {
+    for(var name in trackedMetrics[namespace]) {
+      var metric = trackedMetrics[namespace][name];
+      if(namespace.length > 0) {
+        metric.name = namespace + '.' + name;
+      } else {
+        metric.name = name;
+      }
+      var metricType = Object.getPrototypeOf(metric);
+      if(metricType === Meter.prototype) {
+        meters.push(metric);
+      } else if(metricType == Timer.prototype) {
+        timers.push(metric);
+      } else if(metricType == Counter.prototype) {
+        counters.push(metric);
+      }
+    }
+  }
+
+  return { meters: meters, timers: timers, counters: counters };
+};
+
+module.exports = ScheduledReporter;

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -1,0 +1,23 @@
+var Report = require('../').Report,
+  Counter = require('../').Counter,
+  Timer = require('../').Timer,
+  Meter = require('../').Meter,
+  util = require('util');
+
+function getSampleReport() {
+  var counter = new Counter();
+  counter.inc(5);
+  var timer = new Timer();
+  for (var i = 1; i <= 100; i++) {
+    timer.update(i);
+  }
+  var meter = new Meter();
+  meter.mark(10);
+  var report = new Report();
+  report.addMetric("basicCount", counter);
+  report.addMetric("myapp.Meter", meter);
+  report.addMetric("myapp.Timer", timer);
+  return report;
+}
+
+exports.getSampleReport = getSampleReport;

--- a/tests/test_all.js
+++ b/tests/test_all.js
@@ -21,4 +21,8 @@ compose(
 , require('./meter')
 , require('./histogram')
 , require('./timer')
+, require('./test_scheduled_reporter')
+, require('./test_console_reporter')
+, require('./test_csv_reporter')
+, require('./test_graphite_reporter')
 )();

--- a/tests/test_console_reporter.js
+++ b/tests/test_console_reporter.js
@@ -1,0 +1,20 @@
+var ConsoleReporter = require('../').ConsoleReporter,
+  helper = require('./helper.js');
+
+var test = function(callback) {
+  var report = helper.getSampleReport();
+  var reporter = new ConsoleReporter(report);
+  reporter.report();
+
+  console.log("basicCount should be 5, myapp.Meter should be 10, myapp.Timer should be 100");
+
+  if (typeof callback == 'function') {
+    callback();
+  }
+};
+
+if (module.parent) {
+  module.exports = test;
+} else {
+  test();
+}

--- a/tests/test_csv_reporter.js
+++ b/tests/test_csv_reporter.js
@@ -1,0 +1,56 @@
+var CsvReporter = require('../').CsvReporter,
+  helper = require('./helper.js'),
+  fs = require('fs'),
+  path = require('path'),
+  os = require('os');
+
+var test = function(callback) {
+  var tryCount = 0;
+  var tmpdir;
+  do {
+    tmpdir = os.tmpdir() + Math.random();
+  } while(fs.existsSync(tmpdir) && tryCount++ < 10);
+
+  if(fs.existsSync(tmpdir)) {
+    console.log("Could not find a tmpdir to create after 10 tries.");
+    if (typeof callback == 'function') {
+      callback();
+    }
+  }
+  fs.mkdirSync(tmpdir);
+
+  var report = helper.getSampleReport();
+  var reporter = new CsvReporter(report, tmpdir);
+  console.log("Starting CsvReporter at 1000ms interval reporting to %s", tmpdir);
+  reporter.start(1000);
+
+  var counterFile = path.join(tmpdir, 'basicCount.csv');
+  var meterFile = path.join(tmpdir, 'myapp.Meter.csv');
+  var timerFile = path.join(tmpdir, 'myapp.Timer.csv');
+  var files = [counterFile, meterFile, timerFile];
+
+  setTimeout(function() {
+    console.log("Reading files %s.  Each file should have 1 header and 3 recordings.", files);
+    files.forEach(function(f) {
+      if(fs.existsSync(f)) {
+        console.log("Reading file: %s.", f);
+        var content = fs.readFileSync(f);
+        console.log("File contents:\n%s", content);
+        fs.unlinkSync(f);
+      } else {
+        console.log("File %s does not exist!", f);
+      }
+    });
+    reporter.stop();
+    fs.rmdirSync(tmpdir);
+    if (typeof callback == 'function') {
+      callback();
+    }
+  }, 3500);
+};
+
+if (module.parent) {
+  module.exports = test;
+} else {
+  test();
+}

--- a/tests/test_graphite_reporter.js
+++ b/tests/test_graphite_reporter.js
@@ -1,0 +1,58 @@
+var GraphiteReporter = require('../').GraphiteReporter,
+  helper = require('./helper.js'),
+  net = require('net');
+
+var test = function(callback) {
+  var reporter;
+  var connectCount = 0;
+  var server = net.createServer(function (client) {
+    console.log("Reporter connected.");
+    client.on('data', function(data) {
+      console.log("Got data: %s", data);
+    });
+
+    connectCount++;
+    // On first connect, schedule a disconnect in 5 seconds.
+    if(connectCount == 1) {
+      setTimeout(function () {
+        console.log("Closing client to see if it reconnects.");
+        client.destroy();
+      }, 5000);
+    } else {
+      // On second connect, shutdown in 2.5 secs.
+      setTimeout(function () {
+        console.log("Shutting down reporter and server.");
+        reporter.stop();
+        server.close();
+        if (typeof callback == 'function') {
+          callback();
+        }
+      }, 2500);
+    }
+  });
+
+  server.on('error', function(err) {
+    console.log("Got error :( %s", err);
+  });
+
+  console.log("Starting fake graphite server.");
+  server.listen( function() {
+    var address = server.address();
+    var report = helper.getSampleReport();
+    reporter = new GraphiteReporter(report, "host1", address.address, address.port);
+    reporter.on('log', function(level, msg, exc) {
+      if(exc) {
+        console.log('%s -- %s (%s)', level, msg, exc);
+      } else {
+        console.log('%s -- %s', level, msg);
+      }
+    });
+    reporter.start(1000);
+  });
+};
+
+if (module.parent) {
+  module.exports = test;
+} else {
+  test();
+}

--- a/tests/test_scheduled_reporter.js
+++ b/tests/test_scheduled_reporter.js
@@ -1,0 +1,40 @@
+var ScheduledReporter = require('../').ScheduledReporter,
+  helper = require('./helper.js'),
+  util = require('util');
+
+var test = function(callback) {
+  var invocations = 0;
+
+  function CountingReporter(registry) {
+    CountingReporter.super_.call(this, registry);
+  }
+  util.inherits(CountingReporter, ScheduledReporter);
+
+  CountingReporter.prototype.report = function() {
+    invocations++;
+    console.log("Invocation #%d", invocations);
+  };
+
+  var report = helper.getSampleReport();
+  var reporter = new CountingReporter(report);
+  console.log("Starting reporter on 2000ms interval, running for 11000ms.");
+  reporter.start(2000);
+
+  setTimeout(function() {
+    console.log("Invocation count should be 5, is %d", invocations);
+    console.log("Stopping reporter");
+    reporter.stop();
+    setTimeout(function() {
+      console.log("Invocation count should still be 5, is %d", invocations);
+      if (typeof callback == 'function') {
+        callback();
+      }
+    }, 3000);
+  }, 11000);
+};
+
+if (module.parent) {
+  module.exports = test;
+} else {
+  test();
+}


### PR DESCRIPTION
For #16, this introduces a `ScheduledReporter` interface that those wanting to create their own custom reporters can implement.  It also includes reporters for console, csv, and graphite reporting.  All reporters strive to represent the same behavior as the dropwizard metrics libraries reporters.   One thing missing is the ability to choose the resolution of rates and durations, which currently resolve to seconds and milliseconds respectively (might be a nice future enhancement, or is that important enough to include here?).

`ScheduledReporter` has a `start(intervalInMs)` function for beginning reporting, which calls a `report` function based on the configured interval.   It is up to the implementer to override the `report` method to perform the behavior they wish.  To stop reporting, simply call `stop`.  `ScheduledReporter` is also an `EventEmitter` so implementers may choose to emit custom events that can be used for logging and such (as is done in `GraphiteReporter`).

**ConsoleReporter**

A custom reporter that prints all metrics on console.log at a defined interval.

Example usage:

```javascript
var ConsoleReporter = metrics.ConsoleReporter;
var report = new metrics.Report();
var consoleReporter = new ConsoleReporter(report);
consoleReporter.start(10000);
```

Example output:
```

Counters -----------------------------------------------------------------------
connected-to
             count = 3

Meters -------------------------------------------------------------------------
queued
             count = 8722
         mean rate = 12.11 events/second
     1-minute rate = 12.98 events/second
     1-minute rate = 12.11 events/second
    15-minute rate = 10.10 events/second

Timers -------------------------------------------------------------------------
UserRequests.requestTimer
             count = 17305
         mean rate = 24.02 events/second
     1-minute rate = 25.67 events/second
     1-minute rate = 23.10 events/second
    15-minute rate = 15.22 events/second
               min =  7.00 milliseconds
               max = 525.00 milliseconds
              mean = 156.85 milliseconds
            stddev = 67.13 milliseconds
              50% <= 143.50 milliseconds
              75% <= 191.00 milliseconds
              95% <= 254.00 milliseconds
              98% <= 292.84 milliseconds
              99% <= 337.26 milliseconds
            99.9% <= 512.80 milliseconds
```

**CsvReporter**

A custom reporter that will create a csv file for each metric that is appended to on the defined reporting interval.

Example usage:

```javascript
var CsvReporter = metrics.CsvReporter;
var report = new metrics.Report();
csvReporter = new CsvReporter(report, '/path/to/directory');
csvReporter.start(10000);
```

Example csv contents:

```
--Example counter output--
t,count
1457889699.912,0
1457889710.013,3
1457889720.104,3
1457889730.15,3

--Example meter output--
t,count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit
1457889699.912,146,14.55342902711324,6,6,6,events/second
1457889710.013,273,13.559827149456117,7.393207200098882,6.306037751326734,6.103626933020923,events/second
1457889720.104,338,11.183165696135521,7.6955595971555155,6.415092206661059,6.14311683976342,events/second
1457889730.15,425,10.553237981724275,8.392187834638802,6.604962596749763,6.210067595403533,events/second
1457889740.216,537,10.66830896376351,9.025342597008544,6.790466006351998,6.276487285589423,events/second
1457889750.355,660,10.91342019974866,8.312062653915623,6.709337885440438,6.254706187757993,events/second

--Example timer output--
t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit
1457889699.912,150,318,206.48666666666665,8,70.04233970414198,216.5,271.25,303.0499999999999,310,314.43000000000006,318,14.940239043824702,3.6,3.6,3.6,calls/second,millisecond
1457889710.013,405,318,165.6567901234568,8,65.9542538323502,158,217.5,287.49999999999994,299,309.94,318,20.11223121616924,5.93286512608212,4.106156134805884,3.77104490497006,calls/second,millisecond
1457889720.104,520,318,170.17115384615383,8,63.58172213618375,168,222,280.95,298.15999999999997,308.78999999999996,318,17.202593621807598,8.209550567635338,4.671558651067844,3.9663996858665898,calls/second,millisecond
1457889730.15,705,325,175.57304964539017,8,61.483743323753714,173,222,280,295,308.93999999999994,325,17.501613623951144,10.69634126087566,5.313143074188136,4.190126558940776,calls/second,millisecond
1457889740.216,932,325,177.95493562231772,8,58.53239215660678,177,220.75,277,293,307.66999999999996,325,18.51373631830913,12.856973450335554,5.933447908607099,4.410617071546225,calls/second,millisecond
1457889750.355,1183,325,177.90955198647484,8,56.79651184791325,178.5,219,274,290.41999999999996,303.97000000000025,324.797,19.559861774772244,12.066553482587318,5.988794286293632,4.445938313836983,calls/second,millisecond
```

**GraphiteReporter**

A custom reporter that sends metrics to a graphite server on the carbon tcp interface.

Example usage:

```javascript
var GraphiteReporter = metrics.GraphiteReporter;
var report = new metrics.Report();
var graphiteReporter = new GraphiteReporter(report, 'my.app', '192.168.99.100', 2003);
graphiteReporter.start(30000);
// capture any log events to winston logger.
graphiteReporter.on('log', function(level, msg, ex) {
    log.log(level, msg, ex);
});
```

What is left is to add a basic test suite (I've validated it all with my application, but would be nice to have a repeatable suite of tests) and to update readme/docs where applicable.  But before I do that, would like to get some feedback on the design/approach.  My goal here was to introduce something extensible so others can add more reporters (either in this library proper, or in their own modules).