### PR TITLE
Timer Update

### DIFF
--- a/metrics/timer.js
+++ b/metrics/timer.js
@@ -13,8 +13,25 @@ var Timer = module.exports = function Timer() {
 }
 
 Timer.prototype.update = function(duration) {
+  // Manually adds a duration in ms to the histogram.
   this.histogram.update(duration);
   this.meter.mark();
+}
+
+Timer.prototype.time = function() {
+  // Starts the timer
+  var d = new Date();
+  this.startTime = d.getTime();
+}
+
+Timer.prototype.stop = function() {
+  // Ends and resets the timer.
+  var d = new Date();
+  var endTime =  d.getTime();
+  var timeDiff = endTime - this.startTime;
+  this.histogram.update(timeDiff);
+  this.meter.mark();
+  this.startTime = null;
 }
 
 // delegate these to histogram

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrics",
   "description": "A node.js port of Coda Hale's metrics library.  In use at Yammer.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "repository": {
     "type": "git",
     "url": "git://github.com/mikejihbe/metrics.git"

--- a/test/unit/timer.js
+++ b/test/unit/timer.js
@@ -1,33 +1,31 @@
-var expect = require('chai').expect
+var assert = require('chai').assert
   , describe = require('mocha').describe
   , it = require('mocha').it
   , Timer = require('../../metrics/timer');
 
 describe('Timer', function() {
-  it('should properly record durations.', function(done) {
-    var timer = new Timer();
-
-    var n = 0;
-    var updateInterval = setInterval(function() {
-      timer.update(n++);
-    }, 100);
-
+  it('should properly record durations', function(done) {
+    var timeTest = new Timer();
+    // Run #1
+    timeTest.time();
     setTimeout(function() {
-      clearInterval(updateInterval);
-      timer.tick();
-      expect(timer.count()).to.be.within(8, 12);
-      expect(timer.min()).to.equal(0);
-      expect(timer.max()).to.be.within(8, 12);
-      expect(timer).to.have.property('mean');
-      expect(timer).to.have.property('stdDev');
-      expect(timer).to.have.property('percentiles');
-      expect(timer).to.have.property('values');
-      expect(timer).to.have.property('oneMinuteRate');
-      expect(timer).to.have.property('fiveMinuteRate');
-      expect(timer).to.have.property('fifteenMinuteRate');
-      expect(timer).to.have.property('meanRate');
-      expect(timer).to.have.property('rates');
-      done();
-    }, 1000);
+      timeTest.stop();
+      // When you run a timer.stop(), it increments the count and adds
+      // the duration to the histogram.  There can be a little deviation
+      // but it should be between 699-710 ms.
+      assert.equal(timeTest.count(), 1);
+      assert.isAtLeast(timeTest.mean(), 699);
+      assert.isAtMost(timeTest.mean(), 710);
+      // Run #2 (callbacks make this a bit unclear)
+      timeTest.time();
+      setTimeout(function() {
+        timeTest.stop();
+        // 2 runs with 700ms and 800ms timeouts
+        assert.equal(timeTest.count(), 2);
+        assert.isAtLeast(timeTest.mean(), 740);
+        assert.isAtMost(timeTest.mean(), 760);
+        done();
+      }, 800);
+    }, 700);
   });
 });


### PR DESCRIPTION
Previously, timers in this library required that you time on your own and simply recorded an integer to the histogram.  This update adds actual timers called with time() and stop() that add to the meter and histogram of the timer class.