### PR TITLE
Fix typings for ExponentiallyDecayingSample class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -203,7 +203,7 @@ declare namespace metrics {
     now(): number;
     tick(): void;
     clear(): void;
-    update(val: number, timestamp: number);
+    update(val: number, timestamp?: number);
     weight(time: number): number;
     rescale(): void;
   }


### PR DESCRIPTION
Typings are causing an error on our side because `ExponentiallyDecayingSample.update` method signature is different than `Sample.update`. Marking `timestamp` parameter as optional resolves it (I actually noticed it is in fact optional). 