### PR TITLE
Histogram.update optional timestamp in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ declare namespace metrics {
     sum: number;
 
     clear: () => void;
-    update: (value: number, timestamp: number) => void;
+    update: (value: number, timestamp?: number) => void;
     updateVariance: (value: number) => void;
 
     percentiles: (percentiles: number[]) => ({ [percentile: number]: number });


### PR DESCRIPTION
Adjust TS type declarations to reflect the reality for Histogram type: timestamp is optional.