### PR TITLE
add missing count type to Histogram object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ declare namespace metrics {
     min: number;
     max: number;
     sum: number;
+    count: number;
 
     clear: () => void;
     update: (value: number, timestamp: number) => void;


### PR DESCRIPTION
+ Histogram class contains count variable which is not added to the typing signature https://github.com/mikejihbe/metrics/blob/master/metrics/histogram.js#L18