### PR TITLE
Make Graphite reporter report integer timestamps

### DIFF
--- a/reporting/graphite-reporter.js
+++ b/reporting/graphite-reporter.js
@@ -58,7 +58,7 @@ GraphiteReporter.prototype.report = function() {
   }
   var metrics = this.getMetrics();
   var self = this;
-  var timestamp = (new Date).getTime() / 1000;
+  var timestamp = Math.floor(Date.now() / 1000);
 
   if(metrics.counters.length != 0) {
     metrics.counters.forEach(function (count) {

--- a/test/unit/graphite_reporter.js
+++ b/test/unit/graphite_reporter.js
@@ -72,6 +72,8 @@ describe('GraphiteReporter', function () {
             tsData.forEach(function (metric) {
               expect(metric[0]).to.startsWith('host1.');
             });
+            // Timestamp should contain only digits
+            expect(ts).to.match(/^\d+$/, 'timestamp should be an integer');
           });
           done();
         }, 2500);


### PR DESCRIPTION
Hi, this should fix #54.

It also uses `Date.now()`, which is twice as fast (in Node) than `(new Date).getTime()`.