### PR TITLE
Fix type-safety of getMetric

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -179,7 +179,7 @@ declare namespace metrics {
 
   class Report {
     addMetric: (eventName: string, metric: Metric) => void;
-    getMetric: (eventName: string) => Metric;
+    getMetric: (eventName: string) => Metric | undefined;
     summary: () => { [namespace: string]: { [name: string]: Metric } };
   }
 


### PR DESCRIPTION
When passed a key that does not exist, `getMetric` can potentially return `undefined`: https://github.com/mikejihbe/metrics/blob/master/reporting/report.js#L34