### PR TITLE
Expose license to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A node.js port of Coda Hale's metrics library.  In use at Yammer.",
   "version": "0.1.21",
   "types": "index.d.ts",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/mikejihbe/metrics.git"


### PR DESCRIPTION
This exposes the license given in the README also to npm. Otherwise this packages is considered unlicensed by tools like e.g. Snyk.